### PR TITLE
Fix nonce for CLISP portability and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Currently a side project for learning Common Lisp: Language, packages system, un
 
 CL-KRAKEN imports a small number of functions from the following Common Lisp libraries: DEXADOR, YASON, QURI, LOCAL-TIME, IRONCLAD, and CL-BASE64.
 
-## Compatibility
+## Portability
 
-Currently developed using SBCL 1.4.15. Not tested with other Common Lisps yet, but for now I am not aware of any compatibility limitations with current versions of other implementations. No SBCL-specific system calls are used.
+Developed with SBCL 1.4.15 and tested with ClozureCL 1.11.5 and CLISP 2.49, all on Linux x86/64.
+
+Not tested with other Common Lisps yet. For now I am not aware of portability limitations with other implementations.
 
 ## Usage
 

--- a/src/time.lisp
+++ b/src/time.lisp
@@ -21,5 +21,11 @@
   "Kraken requires the nonce to be an always-increasing unsigned integer
   between 51 and 64 bits in length. For this, we use UNIX-TIME-IN-MICROSECONDS
   above, expressed as a string. This is analogous to the nonce implementations
-  in the various other Kraken API libraries in C, C++, Go, Python, and Ruby."
-  (write-to-string (unix-time-in-microseconds)))
+  in the various other Kraken API libraries in C, C++, Go, Python, and Ruby.
+
+  In CLISP, LOCAL-TIME:NOW returns precision in seconds instead of microseconds,
+  so for lack of a better alternative (from my limited knowledge), it appears we
+  can work around it effectively with CLISP::GET-INTERNAL-REAL-TIME."
+  (write-to-string
+   #+(or sbcl ccl allegro cmu abcl lispworks) (unix-time-in-microseconds)
+   #+clisp (get-internal-real-time)))


### PR DESCRIPTION
- In CLISP, LOCAL-TIME:NOW returns precision in seconds instead of microseconds, so for lack of a better alternative (from my limited knowledge), it appears we can work around it effectively using CLISP::GET-INTERNAL-REAL-TIME instead.

- Update the portability/compatibility section of the README docs now that the code has been tested with ClozureCL and CLISP.