### PR TITLE
ASSETS and ASSET-PAIRS: change &optional params to &key

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,22 @@ To use, git clone the repo into your `~/quicklisp/local-projects` directory, the
 ;;; ASSETS
 ;;; Get data on one or more (or all) assets available on Kraken.
 ;;; Assets are passed as an optional case-insensitive, space-insensitive, comma-delimited string.
-(assets (&optional asset-list-string)
+(assets (&key asset)
 ;;;
 (assets)
-(assets "xbt")
-(assets "xbt,usd,eur,dash,xmr")
-(assets "xbt, USD, eur, JPY, eth, ZEC, ltc")
+(assets :asset "xbt")
+(assets :asset "xbt,usd,eur,dash,xmr")
+(assets :asset "xbt, USD, eur, JPY, eth, ZEC, ltc")
 
 ;;; ASSET PAIRS
 ;;; Get data on one or more (or all) asset pairs tradeable on Kraken.
 ;;; Pairs are passed as an optional case-insensitive, space-insensitive, comma-delimited string.
-(asset-pairs (&optional pair-list-string)
+(asset-pairs (&key pair)
 ;;;
 (asset-pairs)
-(asset-pairs "XBTUSD")
-(asset-pairs "xbteur,ethusd")
-(asset-pairs "XBTUSD, xbteur, ETHJPY, ethgbp")
+(asset-pairs :pair "XBTUSD")
+(asset-pairs :pair "xbteur,ethusd")
+(asset-pairs :pair "XBTUSD, xbteur, ETHJPY, ethgbp")
 
 ;;; OHLC
 ;;; Get OHLC (Open, High, Low, Close) price data for an asset pair.

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -36,7 +36,7 @@
       `rfc1123'  = RFC 1123 time format"
   (get-public "Time"))
 
-(defun assets (&optional asset)
+(defun assets (&key asset)
   "Get asset info.
   URL: https://api.kraken.com/0/public/Assets
   Input:
@@ -51,7 +51,7 @@
   (check-type asset (or string null))
   (get-public "Assets" :params (when (stringp asset) `(("asset" . ,asset)))))
 
-(defun asset-pairs (&optional pair)
+(defun asset-pairs (&key pair)
   "Get tradeable asset pairs.
   URL: https://api.kraken.com/0/public/AssetPairs
   Input:

--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -43,50 +43,50 @@
   (testing "with no argument evaluates to a JSOWN object for all assets"
     (ok (equal (cl-kraken:assets) *all-assets*)))
   (testing "when passed \"XBT\" evals to a JSOWN object for Bitcoin (XBT) asset"
-    (ok (equal (cl-kraken:assets "XBT") *bitcoin-asset*)))
+    (ok (equal (cl-kraken:assets :asset "XBT") *bitcoin-asset*)))
   (testing "when passed \"xbt\" evals to a JSOWN object for Bitcoin (XBT) asset"
-    (ok (equal (cl-kraken:assets "xbt") *bitcoin-asset*)))
+    (ok (equal (cl-kraken:assets :asset "xbt") *bitcoin-asset*)))
   (testing "when passed \"usd,EUR\" evals to a JSOWN object for USD+EUR assets"
-    (ok (equal (cl-kraken:assets "usd,EUR") *usd-and-euro-assets*)))
+    (ok (equal (cl-kraken:assets :asset "usd,EUR") *usd-and-euro-assets*)))
   (testing "when passed \"UsD, euR\" evals to a JSOWN object for USD+EUR assets"
-    (ok (equal (cl-kraken:assets "UsD, euR") *usd-and-euro-assets*)))
+    (ok (equal (cl-kraken:assets :asset "UsD, euR") *usd-and-euro-assets*)))
   (testing "when passed an invalid ASSET, evaluates to unknown asset error"
-    (ok (equal (cl-kraken:assets "abc")
+    (ok (equal (cl-kraken:assets :asset "abc")
                '(:OBJ ("error" "EQuery:Unknown asset")))))
   (testing "when passed an empty ASSET, evaluates to unknown asset error"
-    (ok (equal (cl-kraken:assets "")
+    (ok (equal (cl-kraken:assets :asset "")
                '(:OBJ ("error" "EQuery:Unknown asset")))))
   (testing "when passed a symbol ASSET, a type error is signaled"
-    (ok (signals (cl-kraken:assets 'xbt) 'type-error)
+    (ok (signals (cl-kraken:assets :asset 'xbt) 'type-error)
         "The value of ASSET is XBT, which is not of type (OR STRING NULL)."))
   (testing "when passed a keyword ASSET, a type error is signaled"
-    (ok (signals (cl-kraken:assets :xbt) 'type-error)
+    (ok (signals (cl-kraken:assets :asset :xbt) 'type-error)
         "The value of ASSET is :XBT, which is not of type (OR STRING NULL).")))
 
 (deftest asset-pairs
   (testing "with no argument evaluates to a JSOWN object for all asset pairs"
     (ok (equal (cl-kraken:asset-pairs) *all-pairs*)))
   (testing "when passed \"XBTEUR\" evaluates to a JSOWN object for XBTEUR pair"
-    (ok (equal (cl-kraken:asset-pairs "XBTEUR") *xbteur-pair*)))
+    (ok (equal (cl-kraken:asset-pairs :pair "XBTEUR") *xbteur-pair*)))
   (testing "when passed \"xbteur\" evaluates to a JSOWN object for XBTEUR pair"
-    (ok (equal (cl-kraken:asset-pairs "xbteur") *xbteur-pair*)))
+    (ok (equal (cl-kraken:asset-pairs :pair "xbteur") *xbteur-pair*)))
   (testing "when passed \"xbtusd,xmreur\" evaluates to XBTUSD and XMREUR pairs"
-    (ok (equal (cl-kraken:asset-pairs "xbtusd,xmreur")
+    (ok (equal (cl-kraken:asset-pairs :pair "xbtusd,xmreur")
                *xbtusd-and-xmreur-pairs*)))
   (testing "when passed \" XBTusd ,  xmrEUR \" evals to XBTUSD and XMREUR pairs"
-    (ok (equal (cl-kraken:asset-pairs " XBTusd ,  xmrEUR ")
+    (ok (equal (cl-kraken:asset-pairs :pair " XBTusd ,  xmrEUR ")
                *xbtusd-and-xmreur-pairs*)))
   (testing "when passed an invalid PAIR, evaluates to unknown asset pair error"
-    (ok (equal (cl-kraken:asset-pairs "abc")
+    (ok (equal (cl-kraken:asset-pairs :pair "abc")
                '(:OBJ ("error" "EQuery:Unknown asset pair")))))
   (testing "when passed an empty PAIR, evaluates to unknown asset pair error"
-    (ok (equal (cl-kraken:asset-pairs "")
+    (ok (equal (cl-kraken:asset-pairs :pair "")
                '(:OBJ ("error" "EQuery:Unknown asset pair")))))
   (testing "when passed a symbol PAIR, a type error is signaled"
-    (ok (signals (cl-kraken:asset-pairs 'xbtusd) 'type-error)
+    (ok (signals (cl-kraken:asset-pairs :pair 'xbtusd) 'type-error)
         "The value of PAIR is XBTUSD, which is not of type (OR STRING NULL)."))
   (testing "when passed a keyword PAIR, a type error is signaled"
-    (ok (signals (cl-kraken:asset-pairs :xbtusd) 'type-error)
+    (ok (signals (cl-kraken:asset-pairs :pair :xbtusd) 'type-error)
         "The value of PAIR is :XBTUSD, which is not of type (OR STRING NULL).")))
 
 (deftest ticker


### PR DESCRIPTION
This change creates flexibility in adding additional keyword parameters, because when &OPTIONAL parameters are present, then &KEY parameters cannot be added.

Concretely, I'd like to add a VERBOSE boolean keyword param for all of the API calls, corresponding to the Dexador VERBOSE parameters.
