### PR TITLE
Add VERBOSE boolean keyword param for all API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ To use, git clone the repo into your `~/quicklisp/local-projects` directory, the
 
 ## API
 
+All API calls accept a VERBOSE boolean keyword parameter (T or default NIL) to output the HTTP request headers for verifying and debugging.
+
 ### Public market data API calls
 
 ```lisp
@@ -29,23 +31,23 @@ To use, git clone the repo into your `~/quicklisp/local-projects` directory, the
 ;;; Get data on one or more (or all) assets available on Kraken.
 ;;; Assets are passed as an optional case-insensitive, space-insensitive,
 ;;; comma-delimited string.
-(assets (&key asset)
+(assets &key asset verbose)
 ;;;
 (assets)
 (assets :asset "xbt")
 (assets :asset "xbt,usd,eur,dash,xmr")
-(assets :asset "xbt, USD, eur, JPY, eth, ZEC, ltc")
+(assets :asset "xbt, USD, eur, JPY, eth, ZEC, ltc" :verbose t)
 
 ;;; ASSET PAIRS
 ;;; Get data on one or more (or all) asset pairs tradeable on Kraken.
 ;;; Pairs are passed as an optional case-insensitive, space-insensitive,
 ;;; comma-delimited string.
-(asset-pairs (&key pair)
+(asset-pairs &key pair verbose)
 ;;;
 (asset-pairs)
 (asset-pairs :pair "XBTUSD")
 (asset-pairs :pair "xbteur,ethusd")
-(asset-pairs :pair "XBTUSD, xbteur, ETHJPY, ethgbp")
+(asset-pairs :pair "XBTUSD, xbteur, ETHJPY, ethgbp" :verbose t)
 
 ;;; OHLC
 ;;; Get OHLC (Open, High, Low, Close) price data for an asset pair.
@@ -55,25 +57,28 @@ To use, git clone the repo into your `~/quicklisp/local-projects` directory, the
 ;;;   Permitted values are 1, 5, 15, 30, 60, 240, 1440, 10080, 21600.
 ;;; SINCE is an optional integer Unix Time id to specify from when to return
 ;;;   new committed OHLC data, corresponding to previous OHLC `last' values.
-(ohlc pair &key since (interval 1))
+(ohlc pair &key since (interval 1) verbose)
 ;;;
 (ohlc "xbteur")
 (ohlc "ZECEUR" :since 1548265854)
-(ohlc "EthUsd" :interval 15 :since 1548265854)
+(ohlc "EthUsd" :interval 15 :since 1548265854 :verbose t)
 
 ;;; TICKER
 ;;; Get ticker data for one or more asset pairs.
 ;;; Pairs are passed as a required case-insensitive, space-insensitive,
 ;;; comma-delimited string.
-(ticker pair-list-string)
+(ticker pair &key verbose)
 ;;;
 (ticker "XBTUSD")
 (ticker "xbtusd,etcxbt,XBTEUR")
-(ticker "xbtusd, etcxbt, XBTEUR, XBTGBP")
+(ticker "xbtusd, etcxbt, XBTEUR, XBTGBP" :verbose t)
 
 ;;; SERVER TIME
 ;;; Get Kraken server time. Useful to approximate skew time between server and client.
+(server-time &key verbose)
+;;;
 (server-time)
+(server-time :verbose t)
 ```
 
 

--- a/src/http.lisp
+++ b/src/http.lisp
@@ -26,7 +26,8 @@
            #:post-private))
 (in-package #:cl-kraken/src/http)
 
-(defun get-public (method &key params (scheme +api-scheme+) (host +api-host+))
+(defun get-public (method &key params (scheme +api-scheme+) (host +api-host+)
+                               verbose)
   "HTTP GET request for public API queries."
   (check-type method (and string (not null)))
   (check-type params list)
@@ -34,10 +35,10 @@
   (check-type host   (and string (not null)))
   (let* ((path (concatenate 'string +api-public-path+ method))
          (uri  (make-uri :scheme scheme :host host :path path :query params)))
-    (parse (get uri))))
+    (parse (get uri :verbose verbose))))
 
 (defun post-private (method &key params (scheme +api-scheme+) (host +api-host+)
-                              (key *api-key*) (secret *api-secret*))
+                                 verbose (key *api-key*) (secret *api-secret*))
   "HTTP POST request for private authenticated API queries."
   (check-type method (and string (not null)))
   (check-type params list)
@@ -50,7 +51,7 @@
          (nonce   (nonce-from-unix-time))
          (headers (post-http-headers path nonce key secret))
          (data    `(("nonce" . ,nonce))))
-    (parse (post uri :headers headers :content data))))
+    (parse (post uri :headers headers :content data :verbose verbose))))
 
 (defun post-http-headers (path nonce key secret)
   "Kraken POST HTTP headers must contain the API key and signature."


### PR DESCRIPTION
to enable passing `:verbose t` to DEXADOR to output the HTTP request headers for verifying and debugging.