### PR TITLE
Add MONOTONIC-CLOCK to fix ECL time precision issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,12 @@ Then run the tests using one of the following:
 
 ## Portability
 
-Developed with SBCL 1.4.16 and tested successfully with ClozureCL 1.11.5, CLISP 2.49.92, and ABCL 1.5.0/1.6.0dev, all on Linux x86/64.
+Developed for SBCL 1.4.16 and tested successfully with:
 
-Works with ECL 16.1.3 except for the nonce function, which the private API calls depend on. To be fixed.
+- ABCL 1.5.0 and 1.6.0-dev
+- CLISP 2.49.92
+- ClozureCL 1.11.5
+- ECL 16.1.3
 
 
 ### Author

--- a/src/globals.lisp
+++ b/src/globals.lisp
@@ -7,9 +7,16 @@
 (in-package #:cl-kraken/src/globals)
 
 ;;; User API key and secret
-
-(defparameter *api-key* "abcdef")
-(defparameter *api-secret* "123456")
+(defparameter *api-key*
+  #+(or sbcl ccl clisp abcl allegro cmu lispworks)
+  "api-key-for-other-Common-Lisps"
+  #+ecl
+  "api-key-for-ECL")
+(defparameter *api-secret*
+  #+(or sbcl ccl clisp abcl allegro cmu lispworks)
+  "api-secret-for-other-Common-Lisps"
+  #+ecl
+  "api-secret-for-ECL")
 
 ;;; Global Parameters
 

--- a/src/time.lisp
+++ b/src/time.lisp
@@ -8,6 +8,8 @@
                 #:now
                 #:nsec-of
                 #:timestamp-to-unix)
+  (:import-from #:monotonic-clock
+                #:monotonic-now)
   (:export #:unix-time-in-microseconds
            #:nonce-from-unix-time))
 (in-package #:cl-kraken/src/time)
@@ -24,8 +26,14 @@
   in the various other Kraken API libraries in C, C++, Go, Python, and Ruby.
 
   In CLISP, LOCAL-TIME:NOW returns precision in seconds instead of microseconds,
-  so for lack of a better alternative (from my limited knowledge), it appears we
-  can work around it effectively with CLISP::GET-INTERNAL-REAL-TIME."
+  so for lack of a better alternative from my limited knowledge, it appears we
+  can work around it for now with CLISP::GET-INTERNAL-REAL-TIME.
+
+  ECL has the same issue. Using MONOTONIC-CLOCK:MONOTONIC-NOW appears to work as
+  a replacement nonce for now, but it generates a 13 digit integer instead of a
+  16 digit one and so cannot be used with the same API key and secret as other
+  Common Lisp implementations. Otherwise, Kraken raises invalid nonce errors."
   (write-to-string
-   #+(or sbcl ccl allegro cmu abcl lispworks) (unix-time-in-microseconds)
-   #+clisp (get-internal-real-time)))
+   #+(or sbcl ccl abcl allegro cmu lispworks) (unix-time-in-microseconds)
+   #+clisp (get-internal-real-time)
+   #+ecl (monotonic-now)))

--- a/tests/time.lisp
+++ b/tests/time.lisp
@@ -16,8 +16,10 @@
   (let ((nonce (cl-kraken/src/time:nonce-from-unix-time)))
     (testing "is a string"
       (ok (stringp nonce)))
-    (testing "is 16 characters in length"
-      (ok (= 16 (length nonce))))
+    (testing "is 16 characters in length (13 characters in ECL)"
+      (let ((expected-length #+(or sbcl ccl clisp abcl allegro cmu lispworks) 16
+                             #+ecl 13))
+        (ok (= expected-length (length nonce)))))
     (testing "is continually increasing"
       (let ((old-nonce (parse-integer
                         nonce))


### PR DESCRIPTION
for generating nonces in Embedded Common Lisp.

Add ECL-specific test in TESTS/TIME.

Add ECL-specific API key/secret parameters in SRC/GLOBALS.

Update README docs.