### PR TITLE
Travis-CI: Add MacOS tests in addition to Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: common-lisp
 
 sudo: false
 
+os:
+  - linux
+  - osx
+
 env:
   global:
     - ROSWELL_BRANCH=master
@@ -15,7 +19,10 @@ env:
     - LISP=ecl
 
 matrix:
+  fast_finish: true
   allow_failures:
+    - env: LISP=clisp
+    - env: LISP=abcl
     - env: LISP=ecl
 
 addons:
@@ -24,16 +31,18 @@ addons:
       - libc6-i386
       - openjdk-8-jre
 
-install:
-  - curl -L https://raw.githubusercontent.com/roswell/roswell/$ROSWELL_BRANCH/scripts/install-for-ci.sh | sh
-  - git clone --depth=1 git://github.com/death/monotonic-clock.git ~/common-lisp/monotonic-clock
-  - git clone --depth=1 git://github.com/soemraws/parse-float.git ~/common-lisp/parse-float
-  - ros install fukamachi/rove
-
 cache:
   directories:
     - $HOME/.roswell
     - $HOME/.config/common-lisp
+
+install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install libev; fi
+  - curl -L https://raw.githubusercontent.com/roswell/roswell/$ROSWELL_BRANCH/scripts/install-for-ci.sh | sh
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ros install sbcl; fi
+  - git clone --depth=1 git://github.com/death/monotonic-clock.git ~/common-lisp/monotonic-clock
+  - git clone --depth=1 git://github.com/soemraws/parse-float.git ~/common-lisp/parse-float
+  - ros install fukamachi/rove
 
 script:
   - rove cl-kraken.asd


### PR DESCRIPTION
and allow build failures for CLISP, ABCL, and ECL because they have exhibited unreliable build processes with the current CI pipeline.

Manual testing with them has nevertheless been solid and reliable, so the issue is with the CI process, not the implementations.