### PR TITLE
Improve TIME functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install libev; fi
   - curl -L https://raw.githubusercontent.com/roswell/roswell/$ROSWELL_BRANCH/scripts/install-for-ci.sh | sh
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ros install sbcl; fi
-  - git clone --depth=1 git://github.com/death/monotonic-clock.git ~/common-lisp/monotonic-clock
   - git clone --depth=1 git://github.com/soemraws/parse-float.git ~/common-lisp/parse-float
   - ros install fukamachi/rove
 

--- a/src/globals.lisp
+++ b/src/globals.lisp
@@ -7,16 +7,8 @@
 (in-package #:cl-kraken/src/globals)
 
 ;;; User API key and secret
-(defparameter *api-key*
-  #-ecl
-  "api-key-for-other-Common-Lisps"
-  #+ecl
-  "api-key-for-ECL")
-(defparameter *api-secret*
-  #-ecl
-  "api-secret-for-other-Common-Lisps"
-  #+ecl
-  "api-secret-for-ECL")
+(defparameter *api-key* "api-key")
+(defparameter *api-secret* "api-secret")
 
 ;;; Global Parameters
 

--- a/src/time.lisp
+++ b/src/time.lisp
@@ -19,11 +19,17 @@
   in the various other Kraken API libraries in C, C++, Go, Python, and Ruby."
   (write-to-string (unix-time-in-microseconds)))
 
-#-(or clisp ecl)
+#-(or sbcl clisp ecl)
 (defun unix-time-in-microseconds (&aux (current-time (now)))
   "Unix Time in usec using the LOCAL-TIME library."
   (+ (floor (nsec-of current-time) 1000)
      (* 1000000 (timestamp-to-unix current-time))))
+
+#+sbcl
+(defun unix-time-in-microseconds ()
+  "Unix Time in usec using SBCL's SB-EXT:GET-TIME-OF-DAY."
+  (multiple-value-bind (sec usec) (sb-ext:get-time-of-day)
+    (+ (* 1000000 sec) usec)))
 
 #+clisp
 (defun unix-time-in-microseconds ()

--- a/src/time.lisp
+++ b/src/time.lisp
@@ -12,25 +12,24 @@
            #:generate-kraken-nonce))
 (in-package #:cl-kraken/src/time)
 
-#-ecl
-(defun unix-time-in-microseconds (&aux (current-time (now)))
-  "Unix Epoch Time in microseconds."
-  (+ (floor (nsec-of current-time) 1000)
-     (* 1000000 (timestamp-to-unix current-time))))
-
 (defun generate-kraken-nonce ()
   "Kraken requires the nonce to be an always-increasing unsigned integer
   between 51 and 64 bits in length. For this, we use UNIX-TIME-IN-MICROSECONDS
-  above, expressed as a string. This is analogous to the nonce implementations
-  in the various other Kraken API libraries in C, C++, Go, Python, and Ruby.
+  below, expressed as a string. This is analogous to the nonce implementations
+  in the various other Kraken API libraries in C, C++, Go, Python, and Ruby."
+  (write-to-string (unix-time-in-microseconds)))
 
-  In CLISP, LOCAL-TIME:NOW returns precision in seconds instead of microseconds,
-  so for lack of a better alternative from my limited knowledge, it appears we
-  can work around it for now with CLISP::GET-INTERNAL-REAL-TIME.
+#-(or clisp ecl)
+(defun unix-time-in-microseconds (&aux (current-time (now)))
+  "Unix Time in usec using the LOCAL-TIME library."
+  (+ (floor (nsec-of current-time) 1000)
+     (* 1000000 (timestamp-to-unix current-time))))
 
-  ECL has the same issue, so we use the custom UNIX-TIME-IN-MICROSECONDS below."
-  (write-to-string #+clisp (get-internal-real-time)
-                   #-clisp (unix-time-in-microseconds)))
+#+clisp
+(defun unix-time-in-microseconds ()
+  "Unix Time in usec using CLISP's GET-INTERNAL-REAL-TIME. This is necessary
+  because in CLISP, LOCAL-TIME:NOW returns precision in sec instead of usec."
+  (get-internal-real-time))
 
 #+ecl
 (progn

--- a/src/time.lisp
+++ b/src/time.lisp
@@ -12,6 +12,8 @@
            #:generate-kraken-nonce))
 (in-package #:cl-kraken/src/time)
 
+(defparameter +one-million+ 1000000)
+
 (defun generate-kraken-nonce ()
   "Kraken requires the nonce to be an always-increasing unsigned integer
   between 51 and 64 bits in length. For this, we use UNIX-TIME-IN-MICROSECONDS
@@ -23,13 +25,13 @@
 (defun unix-time-in-microseconds (&aux (current-time (now)))
   "Unix Time in usec using the LOCAL-TIME library."
   (+ (floor (nsec-of current-time) 1000)
-     (* 1000000 (timestamp-to-unix current-time))))
+     (* +one-million+ (timestamp-to-unix current-time))))
 
 #+sbcl
 (defun unix-time-in-microseconds ()
   "Unix Time in usec using SBCL's SB-EXT:GET-TIME-OF-DAY."
   (multiple-value-bind (sec usec) (sb-ext:get-time-of-day)
-    (+ (* 1000000 sec) usec)))
+    (+ (* +one-million+ sec) usec)))
 
 #+(and ccl (not windows))
 (defun unix-time-in-microseconds ()
@@ -37,7 +39,7 @@
   (ccl:rlet ((tv :timeval))
     (let ((err (ccl:external-call "gettimeofday" :address tv :address (ccl:%null-ptr) :int)))
       (assert (zerop err) nil "gettimeofday failed")
-      (+ (* 1000000 (ccl:pref tv :timeval.tv_sec)) (ccl:pref tv :timeval.tv_usec)))))
+      (+ (* +one-million+ (ccl:pref tv :timeval.tv_sec)) (ccl:pref tv :timeval.tv_usec)))))
 
 #+clisp
 (defun unix-time-in-microseconds ()
@@ -62,5 +64,5 @@
     "Unix Time in usec using CFFI to call `gettimeofday' in C."
     (cffi:with-foreign-object (tv '(:struct timeval))
       (gettimeofday tv (cffi::null-pointer))
-      (+ (* 1000000 (cffi:mem-ref tv 'time_t))
+      (+ (* +one-million+ (cffi:mem-ref tv 'time_t))
          (cffi:mem-ref tv 'seconds_t (cffi:foreign-type-size 'time_t))))))

--- a/src/time.lisp
+++ b/src/time.lisp
@@ -4,6 +4,7 @@
 (defpackage #:cl-kraken/src/time
   (:documentation "CL-Kraken time utilities.")
   (:use #:cl)
+  #-(or sbcl (and ccl (not windows)) clisp ecl)
   (:import-from #:local-time
                 #:now
                 #:nsec-of

--- a/tests/time.lisp
+++ b/tests/time.lisp
@@ -16,7 +16,6 @@
   (let ((nonce (cl-kraken/src/time:generate-kraken-nonce)))
     (testing "is a string"
       (ok (stringp nonce)))
-    #-ecl
     (testing "is 16 characters in length"
       (ok (= 16 (length nonce))))
     (testing "is continually increasing"


### PR DESCRIPTION
Notably, this PR fixes UNIX-TIME-IN-MICROSECONDS for ECL using the CFFI (C foreign function interface) to call `gettimeofday` into a C struct which we convert in Common Lisp to Unix Time in microseconds (usec).

This enables ECL to evaluate UNIX-TIME-IN-MICROSECONDS and the resulting nonce to the same value as for the other CL implementations (SBCL, CCL, ABCL), which:

- removes the need for ECL to use a separate API key/secret
- removes the need to customise one of the TIME tests for ECL
- removes the need for the MONOTONIC-CLOCK library

This PR also adds custom UNIX-TIME-IN-MICROSECONDS functions for SBCL and CCL and does some refactoring.