### PR TITLE
Fix/improve a few test predicates

### DIFF
--- a/tests/depth.lisp
+++ b/tests/depth.lisp
@@ -32,14 +32,14 @@
       (destructuring-bind (ask-price ask-volume ask-timestamp) (car asks)
         (ok (simple-string-p ask-price))
         (ok (simple-string-p ask-volume))
-        (ok (typep (parse-float ask-price) 'single-float))
-        (ok (typep (parse-float ask-volume) 'single-float))
+        (ok (floatp (parse-float ask-price)))
+        (ok (floatp (parse-float ask-volume)))
         (ok (integerp ask-timestamp)))
       (destructuring-bind (bid-price bid-volume bid-timestamp) (car bids)
         (ok (simple-string-p bid-price))
         (ok (simple-string-p bid-volume))
-        (ok (typep (parse-float bid-price) 'single-float))
-        (ok (typep (parse-float bid-volume) 'single-float))
+        (ok (floatp (parse-float bid-price)))
+        (ok (floatp (parse-float bid-volume)))
         (ok (integerp bid-timestamp)))))
   ;; Test invalid PAIR values.
   (testing "when passed a multiple PAIR, evaluates to unknown asset pair error"

--- a/tests/ohlc.lisp
+++ b/tests/ohlc.lisp
@@ -48,8 +48,8 @@
         (ok (simple-string-p volume))
         (ok (integerp count))
         (ok (integerp last))
-        (ok (typep high-price 'single-float))
-        (ok (typep low-price  'single-float))
+        (ok (floatp high-price))
+        (ok (floatp low-price))
         (ok (>= high-price low-price))))
     ;; Test correct handling of keyword parameters to query params.
     (testing "when passed no INTERVAL or SINCE, queries default interval of 1"

--- a/tests/time.lisp
+++ b/tests/time.lisp
@@ -15,7 +15,7 @@
 (deftest generate-kraken-nonce
   (let ((nonce (cl-kraken/src/time:generate-kraken-nonce)))
     (testing "is a string"
-      (ok (stringp nonce)))
+      (ok (simple-string-p nonce)))
     (testing "is 16 characters in length"
       (ok (= 16 (length nonce))))
     (testing "is continually increasing"

--- a/tests/trades.lisp
+++ b/tests/trades.lisp
@@ -32,8 +32,8 @@
       (ok (= (length trade) 6))
       (destructuring-bind (price volume time buy/sell market/limit misc) trade
         (ok (simple-string-p price))
+        (ok (simple-string-p volume))
         (ok (typep (parse-float price) 'single-float))
-        (ok (typep volume 'simple-string))
         (ok (typep (parse-float volume) 'single-float))
         (ok (typep time 'ratio))
         (ok (or (string= buy/sell "b") (string= buy/sell "s")))

--- a/tests/trades.lisp
+++ b/tests/trades.lisp
@@ -33,8 +33,8 @@
       (destructuring-bind (price volume time buy/sell market/limit misc) trade
         (ok (simple-string-p price))
         (ok (simple-string-p volume))
-        (ok (typep (parse-float price) 'single-float))
-        (ok (typep (parse-float volume) 'single-float))
+        (ok (floatp (parse-float price)))
+        (ok (floatp (parse-float volume)))
         (ok (typep time 'ratio))
         (ok (or (string= buy/sell "b") (string= buy/sell "s")))
         (ok (or (string= market/limit "m") (string= market/limit "l")))

--- a/tests/trades.lisp
+++ b/tests/trades.lisp
@@ -31,7 +31,7 @@
       (ok (listp trade))
       (ok (= (length trade) 6))
       (destructuring-bind (price volume time buy/sell market/limit misc) trade
-        (ok (typep price '(simple-array character (10))))
+        (ok (simple-string-p price))
         (ok (typep (parse-float price) 'single-float))
         (ok (typep volume 'simple-string))
         (ok (typep (parse-float volume) 'single-float))


### PR DESCRIPTION
- TRADES tests: Fix a test case that began to break. An overly-precise test for PRICE string length broke as soon as the Bitcoin price increased from 4 to 5 digits.

- TIME, TRADES tests: Use SIMPLE-STRING-P where it is a better choice.

- DEPTH, OHLC, TRADES tests: Use more general FLOATP. Test for FLOATP instead of the more specific TYPEP 'SINGLE-FLOAT to be agnostic about float precision chosen by the user.