### PR TITLE
TIME: import from CFFI for ECL, remove prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Allowed failures on Travis are due to CI build issues and not portability ones.
 ## Dependencies
 
 CL-KRAKEN imports a small number of functions from the following Common Lisp
-libraries: DEXADOR, JSOWN, QURI, LOCAL-TIME, IRONCLAD, and CL-BASE64.
+libraries: DEXADOR, JSOWN, QURI, LOCAL-TIME, IRONCLAD, CL-BASE64, and for ECL,
+CFFI.
 
 
 ## Getting started

--- a/src/time.lisp
+++ b/src/time.lisp
@@ -9,6 +9,15 @@
                 #:now
                 #:nsec-of
                 #:timestamp-to-unix)
+  #+ecl
+  (:import-from #:cffi
+                #:defcfun
+                #:defcstruct
+                #:defctype
+                #:foreign-type-size
+                #:mem-ref
+                #:null-pointer
+                #:with-foreign-object)
   (:export #:unix-time-in-microseconds
            #:generate-kraken-nonce))
 (in-package #:cl-kraken/src/time)
@@ -50,20 +59,20 @@
 
 #+ecl
 (progn
-  (cffi:defctype time_t :long)
-  (cffi:defctype seconds_t :int)
+  (defctype time_t :long)
+  (defctype seconds_t :int)
 
-  (cffi:defcstruct timeval
+  (defcstruct timeval
     (tv_sec time_t)
     (tv_usec seconds_t))
 
-  (cffi:defcfun gettimeofday :int
+  (defcfun gettimeofday :int
     (timeval :pointer)
     (pointer :pointer))
 
   (defun unix-time-in-microseconds ()
     "Unix Time in usec using CFFI to call `gettimeofday' in C."
-    (cffi:with-foreign-object (tv '(:struct timeval))
-      (gettimeofday tv (cffi::null-pointer))
-      (+ (* +one-million+ (cffi:mem-ref tv 'time_t))
-         (cffi:mem-ref tv 'seconds_t (cffi:foreign-type-size 'time_t))))))
+    (with-foreign-object (tv '(:struct timeval))
+      (gettimeofday tv (null-pointer))
+      (+ (* +one-million+ (mem-ref tv 'time_t))
+         (mem-ref tv 'seconds_t (foreign-type-size 'time_t))))))


### PR DESCRIPTION
and update the README.