### PR TITLE
Add RAW keyword param to HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,13 @@ To use, git clone the repo into your `~/quicklisp/local-projects` directory, the
 
 ## API
 
-All API calls accept a VERBOSE boolean keyword parameter (T or default NIL) to
-output the HTTP request headers for verifying and debugging.
+All API calls accept the following optional boolean keyword parameters:
+
+- RAW (T or default NIL) for the JSON response be returned as a raw string
+  rather than parsed and converted to a list data structure
+
+- VERBOSE (T or default NIL) to output the HTTP request headers for verifying
+  and debugging
 
 ### Public market data API calls
 
@@ -50,21 +55,21 @@ output the HTTP request headers for verifying and debugging.
 ;;; ASSET PAIRS
 ;;; Get data on one or more (or all) asset pairs tradeable on Kraken.
 ;;; Pairs are passed as an optional case-insensitive, comma-delimited string.
-(asset-pairs &key pair verbose)
+(asset-pairs &key pair raw verbose)
 ;;;
 (asset-pairs)
 (asset-pairs :pair "XBTUSD")
-(asset-pairs :pair "xbteur,ethusd")
-(asset-pairs :pair "XBTUSD, xbteur, ETHJPY, ethgbp" :verbose t)
+(asset-pairs :pair "xbteur,ethusd" :verbose t)
+(asset-pairs :pair "XBTUSD, xbteur, ETHJPY, ethgbp" :raw t :verbose t)
 
 ;;; ASSETS
 ;;; Get data on one or more (or all) assets available on Kraken.
 ;;; Assets are passed as an optional case-insensitive, comma-delimited string.
-(assets &key asset verbose)
+(assets &key asset raw verbose)
 ;;;
 (assets)
 (assets :asset "xbt")
-(assets :asset "xbt,usd,eur,dash,xmr")
+(assets :asset "xbt,usd,eur,dash,xmr" :raw t)
 (assets :asset "xbt, USD, eur, JPY, eth, ZEC, ltc" :verbose t)
 
 ;;; DEPTH (Order Book)
@@ -72,10 +77,10 @@ output the HTTP request headers for verifying and debugging.
 ;;; PAIR is a required case-insensitive string representing a single asset pair
 ;;;   for which to query depth.
 ;;; COUNT is an optional integer of maximum asks and bids to receive.
-(depth pair &key count verbose)
+(depth pair &key count raw verbose)
 ;;;
 (depth "xbteur")
-(depth "ADAXBT" :count 1)
+(depth "ADAXBT" :count 1 :raw t)
 (depth "LtcUsd" :count 10 :verbose t)
 
 ;;; OHLC
@@ -86,49 +91,49 @@ output the HTTP request headers for verifying and debugging.
 ;;;   Permitted values are 1, 5, 15, 30, 60, 240, 1440, 10080, 21600.
 ;;; SINCE is an optional integer Unix Time id to specify from when to return
 ;;;   new committed OHLC data, corresponding to previous OHLC `last' values.
-(ohlc pair &key since (interval 1) verbose)
+(ohlc pair &key since (interval 1) raw verbose)
 ;;;
 (ohlc "xbteur")
-(ohlc "ZECEUR" :since 1548265854)
+(ohlc "ZECEUR" :since 1548265854 :raw t)
 (ohlc "EthUsd" :interval 15 :since 1548265854 :verbose t)
 
 ;;; SERVER TIME
 ;;; Get Kraken server time. Useful to approximate skew time between server and client.
-(server-time &key verbose)
+(server-time &key raw verbose)
 ;;;
 (server-time)
-(server-time :verbose t)
+(server-time :raw t :verbose t)
 
 ;;; SPREAD
 ;;; Get spread price data for an asset pair.
 ;;; PAIR is a required, case-insensitive string representing a single asset pair.
 ;;; SINCE is an optional integer Unix Time id from when to return spread data,
 ;;;   corresponding to previous spread `last' values.
-(spread pair &key since verbose)
+(spread pair &key since raw verbose)
 ;;;
 (spread "XBTEUR")
 (spread "zecjpy" :since 1551009182)
-(spread "EthUsd" :since 1551009182 :verbose t)
+(spread "EthUsd" :since 1551009182 :raw t :verbose t)
 
 ;;; TICKER
 ;;; Get ticker data for one or more asset pairs.
 ;;; Pairs are passed as a required case-insensitive, comma-delimited string.
-(ticker pair &key verbose)
+(ticker pair &key raw verbose)
 ;;;
 (ticker "XBTUSD")
 (ticker "xbtusd,etcxbt,XBTEUR")
-(ticker "xbtusd, etcxbt, XBTEUR, XBTGBP" :verbose t)
+(ticker "xbtusd, etcxbt, XBTEUR, XBTGBP" :raw t :verbose t)
 
 ;;; TRADES
 ;;; Get recent trades for an asset pair.
 ;;; PAIR is a required, case-insensitive string representing a single asset pair.
 ;;; SINCE is an optional integer timestamp id from when to return trades data,
 ;;;   corresponding to previous trades `last' values.
-(trades pair &key since verbose)
+(trades pair &key since raw verbose)
 ;;;
 (trades "xbtusd")
 (trades "ETHGBP" :since 1551123951304758112)
-(trades "ltcUSD" :since 1551123951304758112 :verbose t)
+(trades "ltcUSD" :since 1551123951304758112 :raw t :verbose t)
 ```
 
 

--- a/src/http.lisp
+++ b/src/http.lisp
@@ -25,14 +25,16 @@
   (:export #:request))
 (in-package #:cl-kraken/src/http)
 
-(defun request (method &key post params verbose)
+(defun request (method &key params post raw verbose)
   "General HTTP GET/POST request and JSON parsing function."
   (check-type method (and string (not null)))
-  (check-type post   boolean)
   (check-type params list)
+  (check-type post boolean)
+  (check-type raw boolean)
   (check-type verbose boolean)
-  (let ((function-name (if post 'post-private 'get-public)))
-    (parse (funcall function-name method :params params :verbose verbose))))
+  (let* ((function (if post 'post-private 'get-public))
+         (response (funcall function method :params params :verbose verbose)))
+    (if raw response (parse response))))
 
 (defun get-public (method &key params verbose
                                (scheme +api-scheme+) (host +api-host+))

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -33,7 +33,7 @@
 
 ;;; Kraken Public API
 
-(defun asset-pairs (&key pair verbose)
+(defun asset-pairs (&key pair raw verbose)
   "Get tradeable asset pairs.
   URL: https://api.kraken.com/0/public/AssetPairs
   Input:
@@ -61,12 +61,12 @@
   If an asset pair is on a maker/taker fee schedule, the taker side is given in
     `fees' and maker side in `fees_maker'.
   For asset pairs not on maker/taker, the rates will only be given in `fees'."
-  (declare (type boolean verbose))
+  (declare (type boolean raw verbose))
   (check-type pair (or string null))
   (request "AssetPairs" :params (when (stringp pair) `(("pair" . ,pair)))
-                        :verbose verbose))
+                        :raw raw :verbose verbose))
 
-(defun assets (&key asset verbose)
+(defun assets (&key asset raw verbose)
   "Get asset info.
   URL: https://api.kraken.com/0/public/Assets
   Input:
@@ -78,12 +78,12 @@
       `aclass'           = asset class, currently always set to 'currency'
       `decimals'         = decimal places for record keeping
       `display_decimals' = decimal places for display (usually fewer)"
-  (declare (type boolean verbose))
+  (declare (type boolean raw verbose))
   (check-type asset (or string null))
   (request "Assets" :params (when (stringp asset) `(("asset" . ,asset)))
-                    :verbose verbose))
+                    :raw raw :verbose verbose))
 
-(defun depth (pair &key count verbose)
+(defun depth (pair &key count raw verbose)
   "Get order book public price data for an asset pair.
   URL: https://api.kraken.com/0/public/Depth
   Input:
@@ -92,16 +92,16 @@
   Kraken returns a hash with keys `error' and `result'.
     `result' is an array containing a pair name and the keys `asks' and `bids'
              each followed by an array of `price', `volume', and `timestamp>'."
-  (declare (type boolean verbose))
+  (declare (type boolean raw verbose))
   #+(or sbcl ccl ecl abcl) (declare (type simple-string pair))
   #+(or sbcl ccl ecl) (declare (type (or integer null) count))
   #+clisp (check-type pair simple-string)
   #+(or abcl clisp) (check-type count (or integer null))
   (let ((params `(("pair" . ,pair))))
     (when (integerp count) (push `("count" . ,count) (cdr params)))
-    (request "Depth" :params params :verbose verbose)))
+    (request "Depth" :params params :raw raw :verbose verbose)))
 
-(defun ohlc (pair &key since (interval 1) verbose)
+(defun ohlc (pair &key since (interval 1) raw verbose)
   "Get OHLC (Open, High, Low, Close) public price data for an asset pair.
   URL: https://api.kraken.com/0/public/OHLC
   Input:
@@ -117,7 +117,7 @@
            `time', `open', `high', `low', `close', `VWAP', `volume' and `count'.
        - `last' is a Unix Time id for the current not-yet-committed frame.
            Useful as value for SINCE when querying for new committed OHLC data."
-  (declare (type boolean verbose))
+  (declare (type boolean raw verbose))
   #+(or sbcl ccl ecl abcl) (declare (type simple-string pair))
   #+(or sbcl ccl ecl) (declare (type (or integer null) since)
                                (type integer interval))
@@ -126,19 +126,19 @@
   #+(or abcl clisp) (check-type interval integer)
   (let ((params `(("pair" . ,pair) ("interval" . ,interval))))
     (when (integerp since) (push `("since" . ,since) (cdr params)))
-    (request "OHLC" :params params :verbose verbose)))
+    (request "OHLC" :params params :raw raw :verbose verbose)))
 
-(defun server-time (&key verbose)
+(defun server-time (&key raw verbose)
   "Get server time. Useful to approximate skew time between server and client.
   URL: https://api.kraken.com/0/public/Time
   Kraken returns a hash with keys `error' and `result'.
     `result' is an array of hashes with keys:
       `unixtime' = unix timestamp
       `rfc1123'  = RFC 1123 time format"
-  (declare (type boolean verbose))
-  (request "Time" :verbose verbose))
+  (declare (type boolean raw verbose))
+  (request "Time" :raw raw :verbose verbose))
 
-(defun spread (pair &key since verbose)
+(defun spread (pair &key since raw verbose)
   "Get recent spread data for an asset pair.
   URL: https://api.kraken.com/0/public/Spread
   Input:
@@ -151,16 +151,16 @@
     `result' is an array containing a pair name and a `last' Unix Time id.
        - The pair name contains an array of arrays for `time', `bid', and `ask'.
        - `last' is a Unix Time id to use for SINCE when querying new spread."
-  (declare (type boolean verbose))
+  (declare (type boolean raw verbose))
   #+(or sbcl ccl ecl abcl) (declare (type simple-string pair))
   #+(or sbcl ccl ecl) (declare (type (or integer null) since))
   #+clisp (check-type pair simple-string)
   #+(or abcl clisp) (check-type since (or integer null))
   (let ((params `(("pair" . ,pair))))
     (when (integerp since) (push `("since" . ,since) (cdr params)))
-    (request "Spread" :params params :verbose verbose)))
+    (request "Spread" :params params :raw raw :verbose verbose)))
 
-(defun ticker (pair &key verbose)
+(defun ticker (pair &key raw verbose)
   "Get ticker data for asset pairs.
   URL: https://api.kraken.com/0/public/Ticker
   Input:
@@ -176,11 +176,11 @@
       l = low array                       (today, last 24 hours)
       h = high array                      (today, last 24 hours)
       o = opening price                   (today, at 00:00:00 UTC)"
-  (declare (type boolean verbose))
+  (declare (type boolean raw verbose))
   (check-type pair (and string (not null)))
-  (request "Ticker" :params `(("pair" . ,pair)) :verbose verbose))
+  (request "Ticker" :params `(("pair" . ,pair)) :raw raw :verbose verbose))
 
-(defun trades (pair &key since verbose)
+(defun trades (pair &key since raw verbose)
   "Get recent trades public price data for an asset pair.
   URL: https://api.kraken.com/0/public/Trades
   Input:
@@ -192,21 +192,21 @@
        - The pair name is followed by an array of maximum 1000 trades containing
          `price', `volume', `time', `buy/sell', `market/limit', `miscellaneous'.
        - `last' is a timestamp id to use for SINCE when querying new trades."
-  (declare (type boolean verbose))
+  (declare (type boolean raw verbose))
   #+(or sbcl ccl ecl abcl) (declare (type simple-string pair))
   #+(or sbcl ccl ecl) (declare (type (or integer null) since))
   #+clisp (check-type pair simple-string)
   #+(or abcl clisp) (check-type since (or integer null))
   (let ((params `(("pair" . ,pair))))
     (when (integerp since) (push `("since" . ,since) (cdr params)))
-    (request "Trades" :params params :verbose verbose)))
+    (request "Trades" :params params :raw raw :verbose verbose)))
 
 ;;; Kraken Private API requiring authentication
 
-(defun balance (&key verbose)
-  (declare (type boolean verbose))
-  (request "Balance" :post t :verbose verbose))
+(defun balance (&key raw verbose)
+  (declare (type boolean raw verbose))
+  (request "Balance" :post t :raw raw :verbose verbose))
 
-(defun trade-balance (&key verbose)
+(defun trade-balance (&key raw verbose)
   (declare (type boolean verbose))
-  (request "TradeBalance" :post t :verbose verbose))
+  (request "TradeBalance" :post t :raw raw :verbose verbose))

--- a/src/time.lisp
+++ b/src/time.lisp
@@ -30,7 +30,7 @@
   between 51 and 64 bits in length. For this, we use UNIX-TIME-IN-MICROSECONDS
   below, expressed as a string. This is analogous to the nonce implementations
   in the various other Kraken API libraries in C, C++, Go, Python, and Ruby."
-  (write-to-string (unix-time-in-microseconds)))
+  (princ-to-string (unix-time-in-microseconds)))
 
 #-(or sbcl (and ccl (not windows)) clisp ecl)
 (defun unix-time-in-microseconds (&aux (current-time (now)))

--- a/tests/asset-pairs.lisp
+++ b/tests/asset-pairs.lisp
@@ -5,12 +5,14 @@
   (:import-from #:cl-kraken/tests/kraken-public-data
                 #:*all-pairs*
                 #:*xbteur-pair*
-                #:*xbtusd-and-xmreur-pairs*))
+                #:*xbtusd-and-xmreur-pairs*
+                #:*raw-pairs*))
 (in-package #:cl-kraken/tests/asset-pairs)
 
 (deftest asset-pairs
   (testing "with no argument passed, evaluates to all asset pairs"
     (ok (equal (cl-kraken:asset-pairs) *all-pairs*)))
+  ;; Test PAIR parameter.
   (testing "when passed \"XBTEUR\", evaluates to XBTEUR pair"
     (ok (equal (cl-kraken:asset-pairs :pair "XBTEUR") *xbteur-pair*)))
   (testing "when passed \"xbteur\", evaluates to XBTEUR pair"
@@ -32,4 +34,21 @@
         "The value of PAIR is XBTUSD, which is not of type (OR STRING NULL)."))
   (testing "when passed a keyword PAIR, a type error is signaled"
     (ok (signals (cl-kraken:asset-pairs :pair :xbtusd) 'type-error)
-        "The value of PAIR is :XBTUSD, which is not of type (OR STRING NULL).")))
+        "The value of PAIR is :XBTUSD, which is not of type (OR STRING NULL)."))
+  ;; Test RAW parameter.
+  (testing "when passed RAW T, evaluates to the raw response string"
+    (let ((response (cl-kraken:asset-pairs :pair "xbtusd, xbteur" :raw t)))
+      (ok (stringp response))
+      (ok (string= response *raw-pairs*))))
+  (testing "when passed RAW NIL, evaluates as if no RAW argument was passed"
+    (ok (equal (cl-kraken:asset-pairs :pair "xbteur" :raw nil) *xbteur-pair*)))
+  ;; Test invalid RAW values.
+  (testing "when passed a string RAW, a type error is signaled"
+    (ok (signals (cl-kraken:asset-pairs :raw "1") 'type-error)
+        "The value of RAW is \"1\", which is not of type (MEMBER T NIL)."))
+  (testing "when passed a symbol RAW, a type error is signaled"
+    (ok (signals (cl-kraken:asset-pairs :raw 'a) 'type-error)
+        "The value of RAW is 'a, which is not of type (MEMBER T NIL)."))
+  (testing "when passed a keyword RAW, a type error is signaled"
+    (ok (signals (cl-kraken:asset-pairs :raw :1) 'type-error)
+        "The value of RAW is :|1|, which is not of type (MEMBER T NIL).")))

--- a/tests/assets.lisp
+++ b/tests/assets.lisp
@@ -5,12 +5,14 @@
   (:import-from #:cl-kraken/tests/kraken-public-data
                 #:*all-assets*
                 #:*bitcoin-asset*
-                #:*usd-and-euro-assets*))
+                #:*usd-and-euro-assets*
+                #:*raw-assets*))
 (in-package #:cl-kraken/tests/assets)
 
 (deftest assets
   (testing "with no argument passed, evaluates to all assets"
     (ok (equal (cl-kraken:assets) *all-assets*)))
+  ;; Test ASSET parameter.
   (testing "when passed \"XBT\", evaluates to Bitcoin (XBT) asset"
     (ok (equal (cl-kraken:assets :asset "XBT") *bitcoin-asset*)))
   (testing "when passed \"xbt\", evaluates to Bitcoin (XBT) asset"
@@ -30,4 +32,21 @@
         "The value of ASSET is XBT, which is not of type (OR STRING NULL)."))
   (testing "when passed a keyword ASSET, a type error is signaled"
     (ok (signals (cl-kraken:assets :asset :xbt) 'type-error)
-        "The value of ASSET is :XBT, which is not of type (OR STRING NULL).")))
+        "The value of ASSET is :XBT, which is not of type (OR STRING NULL)."))
+  ;; Test RAW parameter.
+  (testing "when passed RAW T, evaluates to the raw response string"
+    (let ((response (cl-kraken:assets :asset "xbt,usd,eur" :raw t)))
+      (ok (stringp response))
+      (ok (string= response *raw-assets*))))
+  (testing "when passed RAW NIL, evaluates as if no RAW argument was passed"
+    (ok (equal (cl-kraken:assets :asset "xbt" :raw nil) *bitcoin-asset*)))
+  ;; Test invalid RAW values.
+  (testing "when passed a string RAW, a type error is signaled"
+    (ok (signals (cl-kraken:assets :raw "1") 'type-error)
+        "The value of RAW is \"1\", which is not of type (MEMBER T NIL)."))
+  (testing "when passed a symbol RAW, a type error is signaled"
+    (ok (signals (cl-kraken:assets :raw 'a) 'type-error)
+        "The value of RAW is 'a, which is not of type (MEMBER T NIL)."))
+  (testing "when passed a keyword RAW, a type error is signaled"
+    (ok (signals (cl-kraken:assets :raw :1) 'type-error)
+        "The value of RAW is :|1|, which is not of type (MEMBER T NIL).")))

--- a/tests/depth.lisp
+++ b/tests/depth.lisp
@@ -17,6 +17,7 @@
            (pair     (filter result "XXBTZEUR"))
            (asks     (filter pair "asks"))
            (bids     (filter pair "bids")))
+      (ok (consp response))
       (ok (= (length response) 3))
       (ok (eq (first response) :OBJ))
       (ok (equal (second response) '("error")))
@@ -112,4 +113,30 @@
         "The value of INTERVAL is 'a, which is not of type INTEGER."))
   (testing "when passed a keyword INTERVAL, a type error is signaled"
     (ok (signals (cl-kraken:depth "xbteur" :count :1) 'type-error)
-        "The value of INTERVAL is :|1|, which is not of type INTEGER.")))
+        "The value of INTERVAL is :|1|, which is not of type INTEGER."))
+  ;; Test RAW parameter.
+  (testing "when passed RAW T, evaluates to the raw response string"
+    (let* ((response (cl-kraken:depth "xbtusd" :count 1 :raw t))
+           (start (subseq response 0 42)))
+      (ok (stringp response))
+      (ok (string= start "{\"error\":[],\"result\":{\"XXBTZUSD\":{\"asks\":["))))
+  (testing "when passed RAW NIL, evaluates as if no RAW argument was passed"
+    (let* ((response (cl-kraken:depth "xbteur" :count 1 :raw nil))
+           (error!   (filter response "error"))
+           (result   (filter response "result")))
+      (ok (consp response))
+      (ok (= (length response) 3))
+      (ok (eq (first response) :OBJ))
+      (ok (equal (second response) '("error")))
+      (ok (null error!))
+      (ok (consp result))))
+  ;; Test invalid RAW values.
+  (testing "when passed a string RAW, a type error is signaled"
+    (ok (signals (cl-kraken:depth "xbteur" :raw "1") 'type-error)
+        "The value of RAW is \"1\", which is not of type (MEMBER T NIL)."))
+  (testing "when passed a symbol RAW, a type error is signaled"
+    (ok (signals (cl-kraken:depth "xbteur" :raw 'a) 'type-error)
+        "The value of RAW is 'a, which is not of type (MEMBER T NIL)."))
+  (testing "when passed a keyword RAW, a type error is signaled"
+    (ok (signals (cl-kraken:depth "xbteur" :raw :1) 'type-error)
+        "The value of RAW is :|1|, which is not of type (MEMBER T NIL).")))

--- a/tests/depth.lisp
+++ b/tests/depth.lisp
@@ -107,13 +107,13 @@
       (ok (> (length bids) count))))
   (testing "when passed a string COUNT, a type error is signaled"
     (ok (signals (cl-kraken:depth "xbteur" :count "1") 'type-error)
-        "The value of INTERVAL is \"1\", which is not of type INTEGER."))
+        "The value of COUNT is \"1\", which is not of type INTEGER."))
   (testing "when passed a symbol COUNT, a type error is signaled"
     (ok (signals (cl-kraken:depth "xbteur" :count 'a) 'type-error)
-        "The value of INTERVAL is 'a, which is not of type INTEGER."))
-  (testing "when passed a keyword INTERVAL, a type error is signaled"
+        "The value of COUNT is 'a, which is not of type INTEGER."))
+  (testing "when passed a keyword COUNT, a type error is signaled"
     (ok (signals (cl-kraken:depth "xbteur" :count :1) 'type-error)
-        "The value of INTERVAL is :|1|, which is not of type INTEGER."))
+        "The value of COUNT is :|1|, which is not of type INTEGER."))
   ;; Test RAW parameter.
   (testing "when passed RAW T, evaluates to the raw response string"
     (let* ((response (cl-kraken:depth "xbtusd" :count 1 :raw t))

--- a/tests/depth.lisp
+++ b/tests/depth.lisp
@@ -74,7 +74,7 @@
                        (cl-kraken:depth "xbteur" :count count :verbose t)))
            (query    (subseq headers 65 91))
            (expected (concatenate 'string "Depth?pair=xbteur&count="
-                                  (write-to-string count) " ")))
+                                  (princ-to-string count) " ")))
       (ok (string= query expected))))
   (testing "when passed a valid COUNT, evaluates to that number of asks/bids"
     (let* ((count    (+ 1 (random 9)))

--- a/tests/kraken-public-data.lisp
+++ b/tests/kraken-public-data.lisp
@@ -3,7 +3,8 @@
 (in-package #:cl-user)
 (defpackage #:cl-kraken/tests/kraken-public-data
   (:use #:cl)
-  (:export #:*bitcoin-asset*
+  (:export #:*raw-assets*
+           #:*bitcoin-asset*
            #:*usd-and-euro-assets*
            #:*all-assets*
            #:*xbteur-pair*
@@ -12,6 +13,13 @@
 (in-package #:cl-kraken/tests/kraken-public-data)
 
 ;;; Kraken Assets
+
+(defparameter *raw-assets*
+  (concatenate
+   'string "{\"error\":[],\"result\":{"
+   "\"XXBT\":{\"aclass\":\"currency\",\"altname\":\"XBT\",\"decimals\":10,\"display_decimals\":5},"
+   "\"ZEUR\":{\"aclass\":\"currency\",\"altname\":\"EUR\",\"decimals\":4,\"display_decimals\":2},"
+   "\"ZUSD\":{\"aclass\":\"currency\",\"altname\":\"USD\",\"decimals\":4,\"display_decimals\":2}}}"))
 
 (defparameter *bitcoin-asset*
   '(:OBJ ("error")

--- a/tests/kraken-public-data.lisp
+++ b/tests/kraken-public-data.lisp
@@ -7,6 +7,7 @@
            #:*bitcoin-asset*
            #:*usd-and-euro-assets*
            #:*all-assets*
+           #:*raw-pairs*
            #:*xbteur-pair*
            #:*xbtusd-and-xmreur-pairs*
            #:*all-pairs*))
@@ -66,6 +67,30 @@
      ("ZUSD"  :OBJ ("aclass" . "currency") ("altname" .   "USD") ("decimals" .  4) ("display_decimals" . 2)))))
 
 ;;; Kraken Asset Pairs
+
+(defparameter *raw-pairs*
+  (concatenate
+   'string "{\"error\":[],\"result\":{"
+   "\"XXBTZEUR\":{\"altname\":\"XBTEUR\",\"wsname\":\"XBT\\/EUR\","
+   "\"aclass_base\":\"currency\",\"base\":\"XXBT\","
+   "\"aclass_quote\":\"currency\",\"quote\":\"ZEUR\",\"lot\":\"unit\","
+   "\"pair_decimals\":1,\"lot_decimals\":8,\"lot_multiplier\":1,"
+   "\"leverage_buy\":[2,3,4,5],\"leverage_sell\":[2,3,4,5],"
+   "\"fees\":[[0,0.26],[50000,0.24],[100000,0.22],[250000,0.2],[500000,0.18],"
+   "[1000000,0.16],[2500000,0.14],[5000000,0.12],[10000000,0.1]],"
+   "\"fees_maker\":[[0,0.16],[50000,0.14],[100000,0.12],[250000,0.1],"
+   "[500000,0.08],[1000000,0.06],[2500000,0.04],[5000000,0.02],[10000000,0]],"
+   "\"fee_volume_currency\":\"ZUSD\",\"margin_call\":80,\"margin_stop\":40},"
+   "\"XXBTZUSD\":{\"altname\":\"XBTUSD\",\"wsname\":\"XBT\\/USD\","
+   "\"aclass_base\":\"currency\",\"base\":\"XXBT\","
+   "\"aclass_quote\":\"currency\",\"quote\":\"ZUSD\",\"lot\":\"unit\","
+   "\"pair_decimals\":1,\"lot_decimals\":8,\"lot_multiplier\":1,"
+   "\"leverage_buy\":[2,3,4,5],\"leverage_sell\":[2,3,4,5],"
+   "\"fees\":[[0,0.26],[50000,0.24],[100000,0.22],[250000,0.2],[500000,0.18],"
+   "[1000000,0.16],[2500000,0.14],[5000000,0.12],[10000000,0.1]],"
+   "\"fees_maker\":[[0,0.16],[50000,0.14],[100000,0.12],[250000,0.1],"
+   "[500000,0.08],[1000000,0.06],[2500000,0.04],[5000000,0.02],[10000000,0]],"
+   "\"fee_volume_currency\":\"ZUSD\",\"margin_call\":80,\"margin_stop\":40}}}"))
 
 (defparameter *xbteur-pair*
   '(:OBJ ("error")

--- a/tests/ohlc.lisp
+++ b/tests/ohlc.lisp
@@ -13,7 +13,7 @@
 
 (deftest ohlc
   (let* ((unix-now (timestamp-to-unix (now)))
-         (since    (write-to-string unix-now)))
+         (since    (princ-to-string unix-now)))
     (testing "when passed \"xBteuR\", evaluates to XBTEUR OHLC data"
       (let* ((response   (cl-kraken:ohlc "XBTeUr" :since unix-now))
              (error!     (filter response "error"))

--- a/tests/ohlc.lisp
+++ b/tests/ohlc.lisp
@@ -31,6 +31,7 @@
              (last       (filter result "last"))
              (high-price (parse-float high))
              (low-price  (parse-float low)))
+        (ok (consp response))
         (ok (= (length response) 3))
         (ok (null error!))
         (ok (consp result))
@@ -113,4 +114,32 @@
         "The value of SINCE is 'a, which is not of type (OR INTEGER NULL)."))
   (testing "when passed a keyword SINCE, a type error is signaled"
     (ok (signals (cl-kraken:ohlc "xbteur" :since :1) 'type-error)
-        "The value of SINCE is :|1|, which is not of type (OR INTEGER NULL).")))
+        "The value of SINCE is :|1|, which is not of type (OR INTEGER NULL)."))
+  ;; Test RAW parameter.
+  (testing "when passed RAW T, evaluates to the raw response string"
+    (let* ((response (cl-kraken:ohlc "xbtusd"
+                                     :since (timestamp-to-unix (now)) :raw t))
+           (start (subseq response 0 35)))
+      (ok (stringp response))
+      (ok (string= start "{\"error\":[],\"result\":{\"XXBTZUSD\":[["))))
+  (testing "when passed RAW NIL, evaluates as if no RAW argument was passed"
+    (let* ((response (cl-kraken:ohlc "xbteur"
+                                     :since (timestamp-to-unix (now)) :raw nil))
+           (error!   (filter response "error"))
+           (result   (filter response "result")))
+      (ok (consp response))
+      (ok (= (length response) 3))
+      (ok (eq (first response) :OBJ))
+      (ok (equal (second response) '("error")))
+      (ok (null error!))
+      (ok (consp result))))
+  ;; Test invalid RAW values.
+  (testing "when passed a string RAW, a type error is signaled"
+    (ok (signals (cl-kraken:ohlc "xbteur" :raw "1") 'type-error)
+        "The value of RAW is \"1\", which is not of type (MEMBER T NIL)."))
+  (testing "when passed a symbol RAW, a type error is signaled"
+    (ok (signals (cl-kraken:ohlc "xbteur" :raw 'a) 'type-error)
+        "The value of RAW is 'a, which is not of type (MEMBER T NIL)."))
+  (testing "when passed a keyword RAW, a type error is signaled"
+    (ok (signals (cl-kraken:ohlc "xbteur" :raw :1) 'type-error)
+        "The value of RAW is :|1|, which is not of type (MEMBER T NIL).")))

--- a/tests/server-time.lisp
+++ b/tests/server-time.lisp
@@ -43,6 +43,9 @@
          (response  (cl-kraken:server-time))
          (time (filter response "result" "unixtime")))
     (testing "evaluates to the expected server time"
+      (ok (consp response))
+      (ok (consp (cadr (cdaddr response))))
+      (ok (consp (caddr (cdaddr response))))
       (ok (equal response (expected-list time))))
     (testing "evaluates to a Unix Time component expressed as an integer"
       (ok (integerp time)))
@@ -52,6 +55,9 @@
   (let* ((response  (cl-kraken:server-time :raw nil))
          (time (filter response "result" "unixtime")))
     (testing "when passed RAW NIL, evaluates as if no RAW parameter was passed"
+      (ok (consp response))
+      (ok (consp (cadr (cdaddr response))))
+      (ok (consp (caddr (cdaddr response))))
       (ok (equal response (expected-list time)))))
   ;; Test with parameter RAW T
   (let* ((response  (cl-kraken:server-time :raw t))

--- a/tests/server-time.lisp
+++ b/tests/server-time.lisp
@@ -35,7 +35,7 @@
 (defun expected-string (time)
   "Builds the expected response string from an integer Unix Time."
   (concatenate 'string
-               "{\"error\":[],\"result\":{\"unixtime\":" (write-to-string time)
+               "{\"error\":[],\"result\":{\"unixtime\":" (princ-to-string time)
                ",\"rfc1123\":\"" (unix-to-rfc1123 time) "\"}}"))
 
 (deftest server-time

--- a/tests/spread.lisp
+++ b/tests/spread.lisp
@@ -67,4 +67,32 @@
           "The value of SINCE is 'a, which is not of type INTEGER."))
     (testing "when passed a keyword SINCE, a type error is signaled"
       (ok (signals (cl-kraken:spread "xbteur" :since :1) 'type-error)
-          "The value of SINCE is :|1|, which is not of type INTEGER."))))
+          "The value of SINCE is :|1|, which is not of type INTEGER.")))
+  ;; Test RAW parameter.
+  (testing "when passed RAW T, evaluates to the raw response string"
+    (let* ((unix-now (timestamp-to-unix (now)))
+           (response (cl-kraken:spread "xbtusd" :since unix-now :raw t))
+           (start (subseq response 0 34)))
+      (ok (stringp response))
+      (ok (string= start "{\"error\":[],\"result\":{\"XXBTZUSD\":["))))
+  (testing "when passed RAW NIL, evaluates as if no RAW argument was passed"
+    (let* ((unix-now (timestamp-to-unix (now)))
+           (response (cl-kraken:spread "xbteur" :since unix-now :raw nil))
+           (error!   (filter response "error"))
+           (result   (filter response "result")))
+      (ok (consp response))
+      (ok (= (length response) 3))
+      (ok (eq (first response) :OBJ))
+      (ok (equal (second response) '("error")))
+      (ok (null error!))
+      (ok (consp result))))
+  ;; Test invalid RAW values.
+  (testing "when passed a string RAW, a type error is signaled"
+    (ok (signals (cl-kraken:spread "xbteur" :raw "1") 'type-error)
+        "The value of RAW is \"1\", which is not of type (MEMBER T NIL)."))
+  (testing "when passed a symbol RAW, a type error is signaled"
+    (ok (signals (cl-kraken:spread "xbteur" :raw 'a) 'type-error)
+        "The value of RAW is 'a, which is not of type (MEMBER T NIL)."))
+  (testing "when passed a keyword RAW, a type error is signaled"
+    (ok (signals (cl-kraken:spread "xbteur" :raw :1) 'type-error)
+        "The value of RAW is :|1|, which is not of type (MEMBER T NIL).")))

--- a/tests/spread.lisp
+++ b/tests/spread.lisp
@@ -19,6 +19,7 @@
              (result   (filter response "result"))
              (pair     (filter result "XXBTZEUR"))
              (last     (filter result "last")))
+        (ok (consp response))
         (ok (= (length response) 3))
         (ok (eq (first response) :OBJ))
         (ok (equal (second response) '("error")))
@@ -51,7 +52,7 @@
              (query   (subseq headers 65 84)))
         (ok (string= query "Spread?pair=xbteur "))))
     (testing "when passed a valid SINCE, it is present in the query params"
-      (let* ((since   (write-to-string unix-now))
+      (let* ((since   (princ-to-string unix-now))
              (headers (with-output-to-string (*standard-output*)
                         (cl-kraken:spread "xbteur" :since unix-now :verbose t)))
              (query   (subseq headers 65 (+ 90 (length since)))))
@@ -60,10 +61,10 @@
     ;; Test invalid SINCE values.
     (testing "when passed a string SINCE, a type error is signaled"
       (ok (signals (cl-kraken:spread "xbteur" :since "1") 'type-error)
-          "The value of INTERVAL is \"1\", which is not of type INTEGER."))
+          "The value of SINCE is \"1\", which is not of type INTEGER."))
     (testing "when passed a symbol SINCE, a type error is signaled"
       (ok (signals (cl-kraken:spread "xbteur" :since 'a) 'type-error)
-          "The value of INTERVAL is 'a, which is not of type INTEGER."))
-    (testing "when passed a keyword INTERVAL, a type error is signaled"
+          "The value of SINCE is 'a, which is not of type INTEGER."))
+    (testing "when passed a keyword SINCE, a type error is signaled"
       (ok (signals (cl-kraken:spread "xbteur" :since :1) 'type-error)
-          "The value of INTERVAL is :|1|, which is not of type INTEGER."))))
+          "The value of SINCE is :|1|, which is not of type INTEGER."))))

--- a/tests/ticker.lisp
+++ b/tests/ticker.lisp
@@ -21,6 +21,10 @@
            (low      (filter pair "l"))
            (high     (filter pair "h"))
            (open     (filter pair "o")))
+      (ok (consp response))
+      (ok (= (length response) 3))
+      (ok (eq (first response) :OBJ))
+      (ok (equal (second response) '("error")))
       (ok (null error!))
       (ok (consp result))
       (ok (= (length result) 2))
@@ -67,4 +71,34 @@
         "The value of PAIR is XBTEUR, which is not of type (AND STRING (NOT NULL))."))
   (testing "when passed a keyword PAIR, a type error is signaled"
     (ok (signals (cl-kraken:ticker :xbteur) 'type-error)
-        "The value of PAIR is :XBTEUR, which is not of type (AND STRING (NOT NULL)).")))
+        "The value of PAIR is :XBTEUR, which is not of type (AND STRING (NOT NULL))."))
+  ;; Test RAW parameter.
+  (testing "when passed RAW T, evaluates to the raw response string"
+    (let* ((response (cl-kraken:ticker "xbteur" :raw t))
+           (start (subseq response 0 39)))
+      (ok (stringp response))
+      (ok (string= start "{\"error\":[],\"result\":{\"XXBTZEUR\":{\"a\":["))))
+  (testing "when passed RAW NIL, evaluates as if no RAW argument was passed"
+    (let* ((response (cl-kraken:ticker "xbtusd" :raw nil))
+           (error!   (filter response "error"))
+           (result   (filter response "result"))
+           (pair     (filter result "XXBTZUSD")))
+      (ok (consp response))
+      (ok (= (length response) 3))
+      (ok (eq (first response) :OBJ))
+      (ok (equal (second response) '("error")))
+      (ok (null error!))
+      (ok (consp result))
+      (ok (= (length result) 2))
+      (ok (consp pair))
+      (ok (= (length pair) 10))))
+  ;; Test invalid RAW values.
+  (testing "when passed a string RAW, a type error is signaled"
+    (ok (signals (cl-kraken:ticker "xbteur" :raw "1") 'type-error)
+        "The value of RAW is \"1\", which is not of type (MEMBER T NIL)."))
+  (testing "when passed a symbol RAW, a type error is signaled"
+    (ok (signals (cl-kraken:ticker "xbteur" :raw 'a) 'type-error)
+        "The value of RAW is 'a, which is not of type (MEMBER T NIL)."))
+  (testing "when passed a keyword RAW, a type error is signaled"
+    (ok (signals (cl-kraken:ticker "xbteur" :raw :1) 'type-error)
+        "The value of RAW is :|1|, which is not of type (MEMBER T NIL).")))

--- a/tests/time.lisp
+++ b/tests/time.lisp
@@ -6,16 +6,12 @@
 (in-package #:cl-kraken/tests/time)
 
 (deftest +one-million+
-  (testing "is an integer"
-    (ok (integerp cl-kraken/src/time::+one-million+)))
-  (testing "evaluates to 1,000,000"
-    (ok (= cl-kraken/src/time::+one-million+ 1000000))))
+  (testing "evaluates to the integer 1,000,000"
+    (ok (eql cl-kraken/src/time::+one-million+ 1000000))))
 
 (deftest +one-thousand+
-  (testing "is an integer"
-    (ok (integerp cl-kraken/src/time::+one-thousand+)))
-  (testing "evaluates to 1,000"
-    (ok (= cl-kraken/src/time::+one-thousand+ 1000))))
+  (testing "evaluates to the integer 1,000"
+    (ok (eql cl-kraken/src/time::+one-thousand+ 1000))))
 
 (deftest unix-time-in-microseconds
   (let ((time (cl-kraken/src/time:unix-time-in-microseconds)))

--- a/tests/trades.lisp
+++ b/tests/trades.lisp
@@ -84,4 +84,40 @@
         "The value of SINCE is 'a, which is not of type INTEGER."))
   (testing "when passed a keyword SINCE, a type error is signaled"
     (ok (signals (cl-kraken:trades "xbteur" :since :1) 'type-error)
-        "The value of SINCE is :|1|, which is not of type INTEGER.")))
+        "The value of SINCE is :|1|, which is not of type INTEGER."))
+  ;; Test RAW parameter.
+  (testing "when passed RAW T, evaluates to the raw response string"
+    (let* ((response (cl-kraken:trades "xbteur" :raw t))
+           (start (subseq response 0 35)))
+      (ok (stringp response))
+      (ok (string= start "{\"error\":[],\"result\":{\"XXBTZEUR\":[["))))
+  (testing "when passed RAW NIL, evaluates as if no RAW argument was passed"
+    (let* ((response (cl-kraken:trades "xbtusd" :raw nil))
+           (error!   (filter response "error"))
+           (result   (filter response "result"))
+           (last     (filter result "last"))
+           (pair     (filter result "XXBTZUSD"))
+           (trade    (first pair)))
+      (ok (consp response))
+      (ok (= (length response) 3))
+      (ok (eq (first response) :OBJ))
+      (ok (equal (second response) '("error")))
+      (ok (null error!))
+      (ok (consp result))
+      (ok (= (length result) 3))
+      (ok (simple-string-p last))
+      (ok (= (length last) 19))
+      (ok (listp pair))
+      (ok (= (length pair) 1000))
+      (ok (listp trade))
+      (ok (= (length trade) 6))))
+    ;; Test invalid RAW values.
+    (testing "when passed a string RAW, a type error is signaled"
+      (ok (signals (cl-kraken:trades "xbteur" :raw "1") 'type-error)
+          "The value of RAW is \"1\", which is not of type (MEMBER T NIL)."))
+    (testing "when passed a symbol RAW, a type error is signaled"
+      (ok (signals (cl-kraken:trades "xbteur" :raw 'a) 'type-error)
+          "The value of RAW is 'a, which is not of type (MEMBER T NIL)."))
+    (testing "when passed a keyword RAW, a type error is signaled"
+      (ok (signals (cl-kraken:trades "xbteur" :raw :1) 'type-error)
+          "The value of RAW is :|1|, which is not of type (MEMBER T NIL).")))

--- a/tests/trades.lisp
+++ b/tests/trades.lisp
@@ -18,6 +18,7 @@
            (last     (filter result "last"))
            (pair     (filter result "XXBTZUSD"))
            (trade    (first pair)))
+      (ok (consp response))
       (ok (= (length response) 3))
       (ok (eq (first response) :OBJ))
       (ok (equal (second response) '("error")))
@@ -67,7 +68,7 @@
   (testing "when passed an integer SINCE, it is present in the query params"
     (let* ((server-time (filter (server-time) "result" "unixtime"))
            (kraken-time (* server-time 1000 1000 1000))
-           (since       (write-to-string kraken-time))
+           (since       (princ-to-string kraken-time))
            (headers     (with-output-to-string (*standard-output*)
                           (cl-kraken:trades "xbteur" :since kraken-time
                                                      :verbose t)))
@@ -77,10 +78,10 @@
   ;; Test invalid SINCE values.
   (testing "when passed a string SINCE, a type error is signaled"
     (ok (signals (cl-kraken:trades "xbteur" :since "1") 'type-error)
-        "The value of INTERVAL is \"1\", which is not of type INTEGER."))
+        "The value of SINCE is \"1\", which is not of type INTEGER."))
   (testing "when passed a symbol SINCE, a type error is signaled"
     (ok (signals (cl-kraken:trades "xbteur" :since 'a) 'type-error)
-        "The value of INTERVAL is 'a, which is not of type INTEGER."))
-  (testing "when passed a keyword INTERVAL, a type error is signaled"
+        "The value of SINCE is 'a, which is not of type INTEGER."))
+  (testing "when passed a keyword SINCE, a type error is signaled"
     (ok (signals (cl-kraken:trades "xbteur" :since :1) 'type-error)
-        "The value of INTERVAL is :|1|, which is not of type INTEGER.")))
+        "The value of SINCE is :|1|, which is not of type INTEGER.")))


### PR DESCRIPTION
for the JSON response be returned as a raw string, which can be useful for JSON library-agnostic testing, rather than parsed and converted to a list data structure for programmatic use.

Updates:

- HTTP:REQUEST
- All the API calls in MAIN
- Test coverage, including some fixups seen while adding the RAW tests
- API docs in the README
