### PR TITLE
Rove ECL workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,9 @@ cache:
     - $HOME/.config/common-lisp
 
 install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install libev; fi
   - curl -L https://raw.githubusercontent.com/roswell/roswell/$ROSWELL_BRANCH/scripts/install-for-ci.sh | sh
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ros install sbcl; fi
   - git clone --depth=1 git://github.com/soemraws/parse-float.git ~/common-lisp/parse-float
   - ros install fukamachi/rove  # Use Rove master for latest updates
   - if [ "$COVERAGE" = "1" ]; then ros install fukamachi/cl-coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - LISP=abcl
     # - LISP=clisp
     # - LISP=cmucl
-    # - LISP=ecl
+    - LISP=ecl
 
 matrix:
   fast_finish: true

--- a/tests/http.lisp
+++ b/tests/http.lisp
@@ -51,27 +51,33 @@
       (ok (string= headers *expected-query* :start1 51 :end1 78)))))
 
 (deftest post-http-headers
-  (let* ((path   "/0/private/Balance")
-         (nonce  "1234567890123456789")
-         (key    "01dB/y38ooyXBUWpS7XUNguXCk1trgN/LEj7FF8LgHmk3fcvX4dNQIFD")
-         (secret (concatenate 'string
-                              "YS/EXE3mfINjlKeegUVPT0uDUYkUX2Ed0OZp9dzCe1LOs+d"
-                              "9vZErAQKMY9o7WVQlTpvDodSlOONkZK7rngdJNw==")))
-    (testing "with nonce data, evaluates to the correct headers alist"
-      (let ((data     `(("nonce" . ,nonce)))
-            (api-sign (concatenate
-                       'string
-                       "kc0yOGvxuk+LzgTXuvPp3Cs6BvkVhGaGZUNkatqtX2iCb30"
-                       "znwbuVX8JJYdwCisyG/7mScSYl7nZ7ihzvMXrXA==")))
-        (ok (equalp
-             (cl-kraken/src/http::post-http-headers path nonce data key secret)
-             `(("api-key" . ,key) ("api-sign" . ,api-sign))))))
-    (testing "with nonce + params data, evaluates to the correct headers alist"
-      (let ((data     `(("pair" . "xbteur, xbtusd") ("nonce" . ,nonce)))
-            (api-sign (concatenate
-                       'string
-                       "lQjzgTnvmjJ9HMiucF+M3T7cI/VTYjZFptWDbf0uFG6RXLH"
-                       "sedsZaJ8n+HPn8G5exNwkzQC3phqXRqUi7g96Gw==")))
-        (ok (equalp
-             (cl-kraken/src/http::post-http-headers path nonce data key secret)
-             `(("api-key" . ,key) ("api-sign" . ,api-sign))))))))
+  (testing "with nonce data, evaluates to the correct headers alist"
+    (let* ((path "/0/private/Balance")
+           (nonce "1234567890123456789")
+           (key "01dB/y38ooyXBUWpS7XUNguXCk1trgN/LEj7FF8LgHmk3fcvX4dNQIFD")
+           (secret (concatenate 'string
+                                "YS/EXE3mfINjlKeegUVPT0uDUYkUX2Ed0OZp9dzCe1LO"
+                                "s+d9vZErAQKMY9o7WVQlTpvDodSlOONkZK7rngdJNw=="))
+           (data `(("nonce" . ,nonce)))
+           (api-sign (concatenate
+                      'string
+                      "kc0yOGvxuk+LzgTXuvPp3Cs6BvkVhGaGZUNkatqtX2iCb30"
+                      "znwbuVX8JJYdwCisyG/7mScSYl7nZ7ihzvMXrXA==")))
+      (ok (equalp
+           (cl-kraken/src/http::post-http-headers path nonce data key secret)
+           `(("api-key" . ,key) ("api-sign" . ,api-sign))))))
+  (testing "with nonce + params data, evaluates to the correct headers alist"
+    (let* ((path "/0/private/Balance")
+           (nonce "1234567890123456789")
+           (key "01dB/y38ooyXBUWpS7XUNguXCk1trgN/LEj7FF8LgHmk3fcvX4dNQIFD")
+           (secret (concatenate 'string
+                                "YS/EXE3mfINjlKeegUVPT0uDUYkUX2Ed0OZp9dzCe1LO"
+                                "s+d9vZErAQKMY9o7WVQlTpvDodSlOONkZK7rngdJNw=="))
+           (data `(("pair" . "xbteur, xbtusd") ("nonce" . ,nonce)))
+           (api-sign (concatenate
+                      'string
+                      "lQjzgTnvmjJ9HMiucF+M3T7cI/VTYjZFptWDbf0uFG6RXLH"
+                      "sedsZaJ8n+HPn8G5exNwkzQC3phqXRqUi7g96Gw==")))
+      (ok (equalp
+           (cl-kraken/src/http::post-http-headers path nonce data key secret)
+           `(("api-key" . ,key) ("api-sign" . ,api-sign)))))))

--- a/tests/server-time.lisp
+++ b/tests/server-time.lisp
@@ -39,17 +39,17 @@
                ",\"rfc1123\":\"" (unix-to-rfc1123 time) "\"}}"))
 
 (deftest server-time
-  (let* ((now (timestamp-to-unix (now)))
-         (response  (cl-kraken:server-time))
-         (time (filter response "result" "unixtime")))
-    (testing "evaluates to the expected server time"
+  (testing "evaluates to the expected server time"
+    (let* ((now      (timestamp-to-unix (now)))
+           (response (cl-kraken:server-time))
+           (time     (filter response "result" "unixtime")))
       (ok (consp response))
       (ok (consp (cadr (cdaddr response))))
       (ok (consp (caddr (cdaddr response))))
-      (ok (equal response (expected-list time))))
-    (testing "evaluates to a Unix Time component expressed as an integer"
-      (ok (integerp time)))
-    (testing "evaluates to Unix Time ±20 seconds of current time, given skew"
+      (ok (equal response (expected-list time)))
+      ;; evaluates to a Unix Time component expressed as an integer"
+      (ok (integerp time))
+      ;; evaluates to Unix Time ±20 seconds of current time, given skew
       (ok (< (abs (- time now)) 20))))
   ;; Test with parameter RAW NIL
   (let* ((response  (cl-kraken:server-time :raw nil))

--- a/tests/time.lisp
+++ b/tests/time.lisp
@@ -24,8 +24,7 @@
   (testing "is 16 characters in length"
     (ok (= 16 (length (cl-kraken/src/time:generate-kraken-nonce)))))
   (testing "is continually increasing"
-    (let ((old-nonce (parse-integer
-                      (cl-kraken/src/time:generate-kraken-nonce)))
-          (new-nonce (parse-integer
-                      (cl-kraken/src/time:generate-kraken-nonce))))
+    (let ((old-nonce (parse-integer (cl-kraken/src/time:generate-kraken-nonce)))
+          (_ (sleep 0.001))
+          (new-nonce (parse-integer (cl-kraken/src/time:generate-kraken-nonce))))
       (ok (> new-nonce old-nonce)))))

--- a/tests/time.lisp
+++ b/tests/time.lisp
@@ -13,21 +13,19 @@
     (ok (eql cl-kraken/src/time::+one-thousand+ 1000))))
 
 (deftest unix-time-in-microseconds
-  (let ((time (cl-kraken/src/time:unix-time-in-microseconds)))
-    (testing "is an integer"
-      (ok (integerp time)))
-    (testing "is 51 bits in length"
-      (ok (= 51 (integer-length time))))))
+  (testing "is an integer"
+    (ok (integerp (cl-kraken/src/time:unix-time-in-microseconds))))
+  (testing "is 51 bits in length"
+    (ok (= 51 (integer-length (cl-kraken/src/time:unix-time-in-microseconds))))))
 
 (deftest generate-kraken-nonce
-  (let ((nonce (cl-kraken/src/time:generate-kraken-nonce)))
-    (testing "is a string"
-      (ok (simple-string-p nonce)))
-    (testing "is 16 characters in length"
-      (ok (= 16 (length nonce))))
-    (testing "is continually increasing"
-      (let ((old-nonce (parse-integer
-                        nonce))
-            (new-nonce (parse-integer
-                        (cl-kraken/src/time:generate-kraken-nonce))))
-        (ok (> new-nonce old-nonce))))))
+  (testing "is a string"
+    (ok (simple-string-p (cl-kraken/src/time:generate-kraken-nonce))))
+  (testing "is 16 characters in length"
+    (ok (= 16 (length (cl-kraken/src/time:generate-kraken-nonce)))))
+  (testing "is continually increasing"
+    (let ((old-nonce (parse-integer
+                      (cl-kraken/src/time:generate-kraken-nonce)))
+          (new-nonce (parse-integer
+                      (cl-kraken/src/time:generate-kraken-nonce))))
+      (ok (> new-nonce old-nonce)))))


### PR DESCRIPTION
ROVE recently stopped working with ECL due to LET scoping breakage in the case of (1) nested LETs, or (2) LETs that have more than one ROVE TESTING function in their scope.

This PR is a workaround.